### PR TITLE
feat: fully deprecate `@mcansh/vite-svg-sprite-plugin`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,9 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    ["@mcansh/vite-svg-sprite-plugin", "@mcansh/vite-plugin-svg-sprite"]
-  ],
+  "fixed": [],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/hot-rabbits-shave.md
+++ b/.changeset/hot-rabbits-shave.md
@@ -1,7 +1,0 @@
----
-"@mcansh/vite-svg-sprite-plugin": patch
----
-
-feat: fully deprecate `@mcansh/vite-svg-sprite-plugin`
-
-i deprecated this package awhile back after conforming to the vite plugin naming convention (yes, this is a scoped package so things don't really matter). this PR fully deprecates and stops publishing of that package

--- a/.changeset/hot-rabbits-shave.md
+++ b/.changeset/hot-rabbits-shave.md
@@ -1,0 +1,7 @@
+---
+"@mcansh/vite-svg-sprite-plugin": patch
+---
+
+feat: fully deprecate `@mcansh/vite-svg-sprite-plugin`
+
+i deprecated this package awhile back after conforming to the vite plugin naming convention (yes, this is a scoped package so things don't really matter). this PR fully deprecates and stops publishing of that package

--- a/packages/vite-svg-sprite-plugin/package.json
+++ b/packages/vite-svg-sprite-plugin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@mcansh/vite-svg-sprite-plugin",
+  "private": true,
   "version": "0.6.0",
   "repository": {
     "url": "mcansh/vite-plugin-svg-sprite",


### PR DESCRIPTION
i deprecated this package awhile back after conforming to the vite plugin naming convention (yes, this is a scoped package so things don't really matter). this PR fully deprecates and stops publishing of that package