### PR TITLE
chore: refactor deprecation warnings to use Vite logger API

### DIFF
--- a/.changeset/flat-knives-trade.md
+++ b/.changeset/flat-knives-trade.md
@@ -1,0 +1,7 @@
+---
+"@mcansh/vite-plugin-svg-sprite": patch
+---
+
+chore: refactor deprecation warnings to use Vite logger API
+
+create a custom logger and set logLevel to “info” when logging: true is set for the plugin

--- a/.changeset/heavy-radios-train.md
+++ b/.changeset/heavy-radios-train.md
@@ -3,4 +3,3 @@
 ---
 
 add vite 7 support
-

--- a/packages/vite-plugin-svg-sprite/src/index.ts
+++ b/packages/vite-plugin-svg-sprite/src/index.ts
@@ -26,8 +26,8 @@ export type Config = Partial<{
   svgstoreOptions: SVGStoreOptions;
 }>;
 
-export function createSvgSpritePlugin(configOptions: Config): Array<Plugin> {
-	let logger = createLogger(configOptions.logging ? "info" : undefined);
+export function createSvgSpritePlugin(configOptions?: Config): Array<Plugin> {
+	let logger = createLogger(configOptions?.logging ? "info" : undefined);
   return [
     {
       name: `${PLUGIN_NAME}:deprecation`,

--- a/packages/vite-plugin-svg-sprite/src/index.ts
+++ b/packages/vite-plugin-svg-sprite/src/index.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import * as svgo from "svgo";
 import type { Options as SVGStoreOptions } from "svgstore";
 import svgstore from "svgstore";
-import type { Logger, Plugin, ResolvedConfig } from "vite";
+import type { Plugin, ResolvedConfig } from "vite";
 import { createLogger } from "vite";
 
 let svgRegex = /\.svg$/;
@@ -27,7 +27,7 @@ export type Config = Partial<{
 }>;
 
 export function createSvgSpritePlugin(configOptions?: Config): Array<Plugin> {
-	let logger = createLogger(configOptions?.logging ? "info" : undefined);
+  let logger = createLogger(configOptions?.logging ? "info" : undefined);
   return [
     {
       name: `${PLUGIN_NAME}:deprecation`,
@@ -51,8 +51,6 @@ export let DEFAULT_COPY_ATTRS = [
   "stroke-dashoffset",
 ];
 
-let logger: Logger;
-
 export function svgSprite(configOptions?: Config): Array<Plugin> {
   let config: ResolvedConfig;
   let options: Required<Config> = {
@@ -63,7 +61,7 @@ export function svgSprite(configOptions?: Config): Array<Plugin> {
     ...configOptions,
   };
 
-  logger = logger ??= createLogger(options.logging ? "info" : undefined);
+  const logger = createLogger(options.logging ? "info" : undefined);
 
   if (options.logging) {
     logger.warnOnce(

--- a/packages/vite-svg-sprite-plugin/src/index.ts
+++ b/packages/vite-svg-sprite-plugin/src/index.ts
@@ -1,12 +1,21 @@
 import type { Config } from "@mcansh/vite-plugin-svg-sprite";
 import { createSvgSpritePlugin as svgSprite } from "@mcansh/vite-plugin-svg-sprite";
+import type { Plugin } from "vite";
+import pkgJson from "../package.json";
 
 /**
  * @deprecated - this package has been renamed to `@mcansh/vite-plugin-svg-sprite`
  */
-export function createSvgSpritePlugin(configOptions: Config) {
-  console.warn(
-    "this package has been renamed to `@mcansh/vite-plugin-svg-sprite`",
-  );
-  return svgSprite(configOptions);
+export function createSvgSpritePlugin(configOptions: Config): Array<Plugin> {
+  return [
+    {
+      name: pkgJson.name,
+      buildStart() {
+        this.warn(
+          "this package has been renamed to `@mcansh/vite-plugin-svg-sprite`",
+        );
+      },
+    },
+    ...svgSprite(configOptions),
+  ];
 }

--- a/packages/vite-svg-sprite-plugin/src/index.ts
+++ b/packages/vite-svg-sprite-plugin/src/index.ts
@@ -1,12 +1,12 @@
 import type { Config } from "@mcansh/vite-plugin-svg-sprite";
-import { createSvgSpritePlugin as svgSprite } from "@mcansh/vite-plugin-svg-sprite";
+import { svgSprite } from "@mcansh/vite-plugin-svg-sprite";
 import type { Plugin } from "vite";
 import pkgJson from "../package.json";
 
 /**
  * @deprecated - this package has been renamed to `@mcansh/vite-plugin-svg-sprite`
  */
-export function createSvgSpritePlugin(configOptions: Config): Array<Plugin> {
+export function createSvgSpritePlugin(configOptions?: Config): Array<Plugin> {
   return [
     {
       name: pkgJson.name,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - examples/*
 
 onlyBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
+  - "@swc/core"
+  - "@tailwindcss/oxide"
   - esbuild
   - unrs-resolver


### PR DESCRIPTION
create a custom logger and set logLevel to "info" when `logging: true`
is set for the plugin